### PR TITLE
Sync migration history with schema

### DIFF
--- a/prisma/migrations/20250808112156_add_missing_schema_elements/migration.sql
+++ b/prisma/migrations/20250808112156_add_missing_schema_elements/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "Program" AS ENUM ('JBBM', 'NIS');
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "isAI" BOOLEAN NOT NULL DEFAULT false,
+    "bookId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "Book" ADD COLUMN "program" "Program" NOT NULL DEFAULT 'NIS';
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
Add a new migration to sync the database schema with `schema.prisma` by introducing previously missing elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-209ed0d7-4a2a-4db0-a9f6-30213051ca0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-209ed0d7-4a2a-4db0-a9f6-30213051ca0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

